### PR TITLE
fix: move PR template file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Description
+
+Please provide a brief description of the changes made in this pull request.
+
+## Related Issue
+
+Please mention the issue number or describe the problem this pull request addresses.
+
+## Checklist
+- [ ] I have tested my changes locally.
+- [ ] I have added necessary documentation or updated existing documentation.
+- [ ] I have followed the coding style guidelines of this project.
+- [ ] I have added appropriate tests (unit, integration, system).
+- [ ] I have reviewed my changes before submitting this pull request.
+- [ ] I have linked the issue or issues that are solved by the PR if any.
+- [ ] I have assigned this PR to myself.
+- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add unique feature``)


### PR DESCRIPTION
## Description

Move `pull_request_template.md` to the root of the `.github` folder.

## Related Issue

Close #14 